### PR TITLE
refactor: emit wireguard as endpoint

### DIFF
--- a/src/store/uif/parser/uif2singbox.js
+++ b/src/store/uif/parser/uif2singbox.js
@@ -83,21 +83,71 @@ export function ParseSSPluginOpts(pluginOpts) {
   return res.join(';')
 }
 
+export function Endpoint(uif_config) {
+  var setting = DeepCopy(uif_config['setting'])
+  var endpoint = {
+    'type': 'wireguard',
+    'tag': uif_config['tag'],
+    'system': setting['system_interface'],
+    'name': setting['interface_name'],
+    'mtu': setting['mtu'],
+    'address': setting['local_address'],
+    'private_key': setting['private_key'],
+    'workers': setting['workers']
+  }
+
+  if ('listen_port' in setting) {
+    endpoint['listen_port'] = parseInt(setting['listen_port'])
+  }
+
+  var peer = {
+    'address': uif_config['transport']['address'],
+    'port': parseInt(uif_config['transport']['port']),
+    'public_key': setting['peer_public_key'],
+    'allowed_ips': setting['allowed_ips'] ? setting['allowed_ips'] : ['0.0.0.0/0'],
+    'reserved': setting['reserved']
+  }
+
+  if ('pre_shared_key' in setting && setting['pre_shared_key'] != "") {
+    peer['pre_shared_key'] = setting['pre_shared_key']
+  }
+
+  if ('persistent_keepalive_interval' in setting) {
+    peer['persistent_keepalive_interval'] = setting['persistent_keepalive_interval']
+  }
+
+  endpoint['peers'] = [peer]
+
+  if ('dial' in uif_config && 'detour' in uif_config['dial'] &&
+    uif_config['dial']['detour']['tag'] != '') {
+    endpoint['detour'] = uif_config['dial']['detour']['tag']
+  }
+
+  if ('dial' in uif_config && 'tcp_fast_open' in uif_config['dial'] && uif_config['dial']['tcp_fast_open']) {
+    endpoint['tcp_fast_open'] = true
+  }
+  if ('dial' in uif_config && 'tcp_multi_path' in uif_config['dial'] && uif_config['dial']['tcp_multi_path']) {
+    endpoint['tcp_multi_path'] = true
+  }
+
+  return endpoint
+}
+
 export function Outbound(uif_config) {
+  if (uif_config['protocol'] == 'wireguard') {
+    return Endpoint(uif_config)
+  }
+
   var singBoxStyle = Bound(uif_config)
   var protocol = singBoxStyle['type']
   if (protocol == 'freedom') {
     singBoxStyle['type'] = 'direct'
   } else if (protocol != 'block') {
-    singBoxStyle['server'] = uif_config['transport']['address'];
-    singBoxStyle['server_port'] = parseInt(uif_config['transport']['port']);
+    singBoxStyle['server'] = uif_config['transport']['address']
+    singBoxStyle['server_port'] = parseInt(uif_config['transport']['port'])
   }
 
-  if (protocol == 'wireguard') {
-    if ('pre_shared_key' in singBoxStyle && singBoxStyle['pre_shared_key'] == "") {
-      delete singBoxStyle['pre_shared_key']
-    }
-  } else if (protocol == 'shadowsocks') {
+  if (protocol == 'shadowsocks') {
     if ('plugin' in singBoxStyle) {
       if (singBoxStyle['plugin'] == '') {
         singBoxStyle['plugin_opts'] = ''

--- a/tests/unit/parser/UIF2singbox.spec.js
+++ b/tests/unit/parser/UIF2singbox.spec.js
@@ -70,6 +70,45 @@ describe('parser:parse to singBoxStyle config', () => {
     expect(res['type']).toBe('direct')
   });
 
+  it('wireguard endpoint', () => {
+    var rawData = {
+      protocol: 'wireguard',
+      tag: 'wg-ep',
+      transport: {
+        protocol: '',
+        setting: {},
+        tls_type: 'none',
+        tls: {},
+        address: '127.0.0.1',
+        port: 10001
+      },
+      setting: {
+        interface_name: 'wg0',
+        local_address: ['10.0.0.2/32'],
+        private_key: '<private_key>',
+        peer_public_key: '<peer_public_key>',
+        pre_shared_key: '<pre_shared_key>',
+        reserved: [0, 0, 0],
+        workers: 4,
+        system_interface: true,
+        mtu: 1408,
+        allowed_ips: ['0.0.0.0/0']
+      }
+    }
+
+    var res = Outbound(rawData)
+    expect(res['type']).toBe('wireguard')
+    expect(res['tag']).toBe('wg-ep')
+    expect(res['system']).toBe(true)
+    expect(res['name']).toBe('wg0')
+    expect(res['address']).toEqual(['10.0.0.2/32'])
+    expect(res['peers'][0]['address']).toBe('127.0.0.1')
+    expect(res['peers'][0]['port']).toBe(10001)
+    expect(res['peers'][0]['public_key']).toBe('<peer_public_key>')
+    expect(res['server']).toBeUndefined()
+    expect(res['server_port']).toBeUndefined()
+  })
+
   it('trojan ws', () => {
     var rawData = {
       protocol: "trojan",


### PR DESCRIPTION
## Summary
- add Endpoint helper that maps WireGuard settings into new endpoint schema
- emit WireGuard configs via endpoints and drop server/server_port usage
- test WireGuard endpoint conversion

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run test:unit` *(fails: multiple suites due to missing environment configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68905a0356488333a0bcf618755fe37d