### PR TITLE
Refactor wireguard peer configuration

### DIFF
--- a/src/store/uif/parser/uif2singbox.js
+++ b/src/store/uif/parser/uif2singbox.js
@@ -89,13 +89,18 @@ export function Outbound(uif_config) {
   if (protocol == 'freedom') {
     singBoxStyle['type'] = 'direct'
   } else if (protocol != 'block') {
-    singBoxStyle['server'] = uif_config['transport']['address'];
-    singBoxStyle['server_port'] = parseInt(uif_config['transport']['port']);
+    if (protocol != 'wireguard') {
+      singBoxStyle['server'] = uif_config['transport']['address'];
+      singBoxStyle['server_port'] = parseInt(uif_config['transport']['port']);
+    }
   }
 
   if (protocol == 'wireguard') {
-    if ('pre_shared_key' in singBoxStyle && singBoxStyle['pre_shared_key'] == "") {
-      delete singBoxStyle['pre_shared_key']
+    if ('peers' in singBoxStyle && singBoxStyle['peers'].length > 0) {
+      var peer = singBoxStyle['peers'][0]
+      if ('pre_shared_key' in peer && peer['pre_shared_key'] == "") {
+        delete peer['pre_shared_key']
+      }
     }
   } else if (protocol == 'shadowsocks') {
     if ('plugin' in singBoxStyle) {

--- a/src/store/uif/uif.js
+++ b/src/store/uif/uif.js
@@ -636,16 +636,18 @@ function GetWarp() {
       data = data.data["res"];
       console.log(data);
       console.log(outbound_obj);
+      if (!("peers" in outbound_obj.setting)) {
+        outbound_obj.setting["peers"] = [{}];
+      }
       outbound_obj.setting["private_key"] = data["PrivateKey"];
-      outbound_obj.setting["peer_public_key"] = data["PublicKey"];
-      outbound_obj.setting["peer_public_key"] = data["PublicKey"];
-      outbound_obj.setting["reserved"] = data["ClientID"];
-      outbound_obj.setting["local_address"] = [
+      outbound_obj.setting["address"] = [
         data["Address1"] + "/32",
         data["Address2"] + "/128",
       ];
-      outbound_obj.transport["address"] = data["EndpointAddress"];
-      outbound_obj.transport["port"] = parseInt(data["EndpointPort"]);
+      outbound_obj.setting["peers"][0]["public_key"] = data["PublicKey"];
+      outbound_obj.setting["peers"][0]["reserved"] = data["ClientID"];
+      outbound_obj.setting["peers"][0]["address"] = data["EndpointAddress"];
+      outbound_obj.setting["peers"][0]["port"] = parseInt(data["EndpointPort"]);
 
       Message({
         type: "success",

--- a/src/uif_views/outbounds/my_servers/proxy/wireguard.vue
+++ b/src/uif_views/outbounds/my_servers/proxy/wireguard.vue
@@ -10,9 +10,9 @@
       </el-col>
 
       <el-col :xs="24" :sm="12" :md="8" :lg="8" :xl="8">
-        <el-form-item label="local_address">
+        <el-form-item label="address">
           <el-select
-            v-model="outbound_obj.setting.local_address"
+            v-model="outbound_obj.setting.address"
             multiple
             filterable
             allow-create
@@ -42,7 +42,7 @@
       <el-col :xs="24" :sm="12" :md="8" :lg="8" :xl="8">
         <el-form-item label="公钥">
           <el-input
-            v-model="outbound_obj.setting.peer_public_key"
+            v-model="outbound_obj.setting.peers[0].public_key"
             placeholder="必填"
           ></el-input>
         </el-form-item>
@@ -51,17 +51,23 @@
       <el-col :xs="24" :sm="12" :md="8" :lg="8" :xl="8">
         <el-form-item label="pre_shared_key">
           <el-input
-            v-model="outbound_obj.setting.pre_shared_key"
+            v-model="outbound_obj.setting.peers[0].pre_shared_key"
             placeholder="选填"
           ></el-input>
         </el-form-item>
       </el-col>
 
       <el-col :xs="24" :sm="12" :md="8" :lg="8" :xl="8">
-        <el-form-item label="workers">
+        <el-form-item label="system">
+          <el-switch v-model="outbound_obj.setting.system"> </el-switch>
+        </el-form-item>
+      </el-col>
+
+      <el-col :xs="24" :sm="12" :md="8" :lg="8" :xl="8">
+        <el-form-item label="listen_port">
           <el-input
-            v-model.number="outbound_obj.setting.workers"
-            placeholder="必填"
+            v-model.number="outbound_obj.setting.listen_port"
+            placeholder="选填"
             type="number"
           ></el-input>
         </el-form-item>
@@ -76,11 +82,56 @@
           ></el-input>
         </el-form-item>
       </el-col>
+    </el-row>
 
-      <el-col :xs="24" :sm="12" :md="8" :lg="8" :xl="8" v-if="false">
-        <el-form-item label="system_interface">
-          <el-switch v-model="outbound_obj.setting.system_interface">
-          </el-switch>
+    <el-row :gutter="5">
+      <el-col :xs="24" :sm="12" :md="8" :lg="8" :xl="8">
+        <el-form-item label="peer_address">
+          <el-input
+            v-model="outbound_obj.setting.peers[0].address"
+            placeholder="必填"
+          ></el-input>
+        </el-form-item>
+      </el-col>
+
+      <el-col :xs="24" :sm="12" :md="8" :lg="8" :xl="8">
+        <el-form-item label="peer_port">
+          <el-input
+            v-model.number="outbound_obj.setting.peers[0].port"
+            placeholder="必填"
+            type="number"
+          ></el-input>
+        </el-form-item>
+      </el-col>
+
+      <el-col :xs="24" :sm="12" :md="8" :lg="8" :xl="8">
+        <el-form-item label="allowed_ips">
+          <el-select
+            v-model="outbound_obj.setting.peers[0].allowed_ips"
+            multiple
+            filterable
+            allow-create
+            default-first-option
+            placeholder="选填"
+          >
+            <el-option
+              v-for="item in ['0.0.0.0/0', '::/0']"
+              :key="item"
+              :label="item"
+              :value="item"
+            >
+            </el-option>
+          </el-select>
+        </el-form-item>
+      </el-col>
+
+      <el-col :xs="24" :sm="12" :md="8" :lg="8" :xl="8">
+        <el-form-item label="persistent_keepalive_interval">
+          <el-input
+            v-model.number="outbound_obj.setting.peers[0].persistent_keepalive_interval"
+            placeholder="选填"
+            type="number"
+          ></el-input>
         </el-form-item>
       </el-col>
     </el-row>
@@ -89,7 +140,7 @@
       <el-col :xs="24" :sm="12" :md="8" :lg="8" :xl="8">
         <el-form-item label="reserved1">
           <el-input
-            v-model.number="outbound_obj.setting.reserved[0]"
+            v-model.number="outbound_obj.setting.peers[0].reserved[0]"
             placeholder="必填"
           ></el-input>
         </el-form-item>
@@ -98,7 +149,7 @@
       <el-col :xs="24" :sm="12" :md="8" :lg="8" :xl="8">
         <el-form-item label="reserved2">
           <el-input
-            v-model.number="outbound_obj.setting.reserved[1]"
+            v-model.number="outbound_obj.setting.peers[0].reserved[1]"
             placeholder="必填"
           ></el-input>
         </el-form-item>
@@ -107,7 +158,7 @@
       <el-col :xs="24" :sm="12" :md="8" :lg="8" :xl="8">
         <el-form-item label="reserved3">
           <el-input
-            v-model.number="outbound_obj.setting.reserved[2]"
+            v-model.number="outbound_obj.setting.peers[0].reserved[2]"
             placeholder="必填"
           ></el-input>
         </el-form-item>
@@ -129,15 +180,23 @@ export default {
   },
   created() {
     var setting = {
-      interface_name: "",
-      local_address: ["172.16.0.2/32"],
+      name: "",
+      address: ["172.16.0.2/32"],
       private_key: "YNXtAzepDqRv9H52osJVDQnznT5AM11eCK3ESpwSt04=",
-      peer_public_key: "Z1XXLsKYkYxuiYjJIkRvtIKFepCYHTgON+GwPq7SOV4=",
-      pre_shared_key: "",
-      reserved: [0, 0, 0],
-      workers: 4,
-      system_interface: false,
+      listen_port: 0,
+      system: false,
       mtu: 1280,
+      peers: [
+        {
+          public_key: "Z1XXLsKYkYxuiYjJIkRvtIKFepCYHTgON+GwPq7SOV4=",
+          pre_shared_key: "",
+          address: "",
+          port: 0,
+          allowed_ips: [],
+          persistent_keepalive_interval: 0,
+          reserved: [0, 0, 0],
+        },
+      ],
     };
     this.outbound_obj.setting = InitSetting(this.outbound_obj.setting, setting);
   },
@@ -150,6 +209,19 @@ export default {
       GetWarp: "uif/GetWarp",
     }),
     FillWarp() {
+      if (!("peers" in this.outbound_obj.setting)) {
+        this.$set(this.outbound_obj.setting, "peers", [
+          {
+            public_key: "",
+            pre_shared_key: "",
+            address: "",
+            port: 0,
+            allowed_ips: [],
+            persistent_keepalive_interval: 0,
+            reserved: [0, 0, 0],
+          },
+        ]);
+      }
       this.GetWarp();
     },
   },


### PR DESCRIPTION
## Summary
- support nested peer structure in wireguard outbound config
- add system, listen port, and peer endpoint options
- update Warp helpers and parser for new wireguard format

## Testing
- `npm run lint` *(fails: Strings must use singlequote, Extra semicolon, Unexpected trailing comma, ...)*
- `npm run test:unit` *(fails: parser:parse to singBoxStyle config › trojan ws, parser:parse to singBoxStyle config › multiplex, Test suite failed to run ...)*

------
https://chatgpt.com/codex/tasks/task_e_68905c0344dc8333ba1771c170908d44