### PR TITLE
feat: move wireguard configs to endpoints

### DIFF
--- a/src/uif/template/tun_fakeip.js
+++ b/src/uif/template/tun_fakeip.js
@@ -114,6 +114,7 @@ var template = {
     "independent_cache": true
   },
   "inbounds": [],
+  "endpoints": [],
   "outbounds": [{
     "type": "selector",
     "tag": "proxy",
@@ -327,7 +328,11 @@ export function BuildEnableOutList(res, outbounds) {
     }
     var out = Outbound(item) // parse uif style to sing-box style.
     var tag = out['tag']
-    res['outbounds'].push(out);
+    if (item['protocol'] == 'wireguard') {
+      res['endpoints'].push(out)
+    } else {
+      res['outbounds'].push(out)
+    }
     enabledOutTag.push(tag)
   }
 
@@ -481,6 +486,18 @@ export function SetAllOutboudFreedom(res) {
       continue
     }
     destList.push(address)
+  }
+  for (var item in res['endpoints']) {
+    item = res['endpoints'][item]
+    if (item['type'] != 'wireguard' || !('peers' in item)) {
+      continue
+    }
+    for (var peer in item['peers']) {
+      var p = item['peers'][peer]
+      if ('address' in p) {
+        destList.push(p['address'])
+      }
+    }
   }
   return destList
 }

--- a/src/uif/template/tun_fakeip_new
+++ b/src/uif/template/tun_fakeip_new
@@ -115,6 +115,7 @@ var template = {
     "independent_cache": true
   },
   "inbounds": [],
+  "endpoints": [],
   "outbounds": [{
     "type": "selector",
     "tag": "proxy",
@@ -328,7 +329,11 @@ export function BuildEnableOutList(res, outbounds) {
     }
     var out = Outbound(item) // parse uif style to sing-box style.
     var tag = out['tag']
-    res['outbounds'].push(out);
+    if (item['protocol'] == 'wireguard') {
+      res['endpoints'].push(out)
+    } else {
+      res['outbounds'].push(out)
+    }
     enabledOutTag.push(tag)
   }
 
@@ -482,6 +487,18 @@ export function SetAllOutboudFreedom(res) {
       continue
     }
     destList.push(address)
+  }
+  for (var item in res['endpoints']) {
+    item = res['endpoints'][item]
+    if (item['type'] != 'wireguard' || !('peers' in item)) {
+      continue
+    }
+    for (var peer in item['peers']) {
+      var p = item['peers'][peer]
+      if ('address' in p) {
+        destList.push(p['address'])
+      }
+    }
   }
   return destList
 }


### PR DESCRIPTION
## Summary
- add `endpoints` array to tun_fakeip templates for WireGuard
- push WireGuard definitions into `endpoints` and reference their tags
- include endpoint peer addresses when building freedom routing

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 4899 errors, 902 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68905cb90a9483338f289670e561db00